### PR TITLE
update debian iso location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ fedora-install: build/fedora/27/fedora-27
 ### Debian images
 ###
 DEBIAN_MIRROR=http://cdimage.debian.org/debian-cd
-STRETCH_BASE=debian-9.3.0-amd64-netinst.iso
+STRETCH_BASE=debian-9.4.0-amd64-netinst.iso
 STRETCH_URL=${DEBIAN_MIRROR}/current/amd64/iso-cd/${STRETCH_BASE}
 
 build/debian:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Templates can be found here: https://github.com/kaorimatz/packer-templates
 make -j`nproc`
 ```
 
+Not counting download speed, general times can range from 2-10 minutes
+
+Debian: 10 minutes
+
+Ubuntu: 2 minutes
+
 ### Other useful commands
 
 To clear out build artifacts

--- a/debian-stretch.json
+++ b/debian-stretch.json
@@ -1,7 +1,7 @@
 {
   "builders": [{
     "type": "qemu",
-    "iso_url": "base/debian-9.3.0-amd64-netinst.iso",
+    "iso_url": "base/debian-9.4.0-amd64-netinst.iso",
     "iso_checksum": "{{user `iso_checksum`}}",
     "iso_checksum_type": "{{user `iso_checksum_type`}}",
     "output_directory": "build/debian/stretch",
@@ -9,7 +9,7 @@
     "disk_compression": true,
     "vm_name": "debian-stretch",
     "disk_size": "{{user `disk_size`}}",
-    "headless": "false",
+    "headless": "true",
     "accelerator": "kvm",
     "http_directory": "http",
     "boot_wait": "5s",
@@ -26,7 +26,7 @@
     "qemuargs": [
       ["-m", "{{user `memory`}}"],
       ["-smp", "{{user `cpus`}}"],
-      ["-display", "gtk"]
+      ["-nographic"]
     ]
   }], 
   "provisioners": [{
@@ -45,7 +45,7 @@
     "compression_level": "6",
     "cpus": "1",
     "disk_size": "40000",
-    "iso_checksum": "83480be837710a76fd4e75a6573ca110e06f5a7589d2d3852bdb0f45749800b3",
+    "iso_checksum": "124d270006703f2111224dec3bf7a9d01450168be41d4834f88fdd035552b044",
     "iso_checksum_type": "sha256",
     "memory": "512",
     "mirror": "http://mirror.deterlab.net/mirrors/debian-cd",


### PR DESCRIPTION
Debian stretch json now uses headless, if you want to keep it out
let me know and I'll remove it.  Kept it in there to test on my
machine.